### PR TITLE
SDE-1726_add_wwpn_candidates

### DIFF
--- a/app/models/manageiq/providers/inventory/persister/builder/storage_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/storage_manager.rb
@@ -30,6 +30,10 @@ module ManageIQ::Providers
         def volume_mappings
           add_common_default_values
         end
+
+        def wwpn_candidates
+          add_common_default_values
+        end
       end
     end
   end

--- a/app/models/manageiq/providers/storage_manager.rb
+++ b/app/models/manageiq/providers/storage_manager.rb
@@ -42,6 +42,9 @@ module ManageIQ::Providers
     has_many :cloud_object_store_containers, :foreign_key => :ems_id, :dependent => :destroy
     has_many :cloud_object_store_objects,    :foreign_key => :ems_id
 
+    has_many :wwpn_candidates, :foreign_key => :ems_id, :dependent => :destroy,
+             :inverse_of => :ext_management_system
+
     belongs_to :parent_manager,
                :foreign_key => :parent_ems_id,
                :class_name  => "ManageIQ::Providers::BaseManager",

--- a/app/models/physical_storage.rb
+++ b/app/models/physical_storage.rb
@@ -29,6 +29,8 @@ class PhysicalStorage < ApplicationRecord
   has_many :canister_computer_systems, :through => :canisters, :source => :computer_system
   has_many :guest_devices, :through => :hardware
 
+  has_many :wwpn_candidates, :dependent => :destroy
+
   supports :refresh_ems
   supports_not :create
   supports_not :delete

--- a/app/models/wwpn_candidate.rb
+++ b/app/models/wwpn_candidate.rb
@@ -1,0 +1,4 @@
+class WwpnCandidate < ApplicationRecord
+  belongs_to :ext_management_system
+  belongs_to :physical_storage
+end

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -6319,6 +6319,10 @@
       :description: Edit Tags of Host Initiators
       :feature_type: control
       :identifier: host_initiator_tag
+    - :name: WWPN Candidates
+      :description: Retrieve fc wwpn candidate for parent storage
+      :feature_type: control
+      :identifier: wwpn_candidates
   - :name: Modify
     :description: Modify Host Initiator
     :feature_type: admin


### PR DESCRIPTION
When creating host initiator, for FC ports,
we need to fill in wwpn
So-called wwpn candidates will be populated to help make a choice
 